### PR TITLE
관련 기사 (헤드라인, 사진, 좋아요수, 스크랩 수) API 추가

### DIFF
--- a/src/main/java/team/backend/curio/controller/UserActionController.java
+++ b/src/main/java/team/backend/curio/controller/UserActionController.java
@@ -9,6 +9,8 @@ import team.backend.curio.service.UserActionService;
 @RequestMapping("/articles")
 @RequiredArgsConstructor
 
+// TODO: PR 제작용 주석
+
 public class UserActionController {
 
     private final UserActionService userActionService;


### PR DESCRIPTION
### 이슈 설명:
/api/articles/{article_id}/related 경로의 GET API 가 구현되었습니다.
이 API는 특정 기사에 대한 관련 기사를 조회하는 기능을 제공,
특정 기사(articleId)의 카테고리를 기반으로 관련된 다른 기사들을 가져옵니다.
반환되는 데이터는 기사 제목 (타이틀), 이미지 URL, 좋아요 수, 스크랩 수를 포함하고 있습니다.
각 관련 기사는 헤드라인, 이미지 URL, 좋아요 수, 스크랩 수가 함께 반환됩니다.

### 요청 예시:
``
### 응답 예시:

`{
  "status": "success",
  "article_id": 123,
  "related_articles": [
    {
      "id": 456,
      "headline": "AI 뉴스 요약 기술의 미래",
      "image_url": "https://news.example.com/images/456.jpg",
      "likeCount": 1,
      "scrapCount": 1
    },
    {
      "id": 789,
      "headline": "뉴스 소비 방식의 변화",
      "image_url": "https://news.example.com/images/789.jpg",
      "likeCount": 1,
      "scrapCount": 1
    },
    {
      "title": "‘가평전투’ 참전 캐나다 용사 유해, 부산 유엔기념공원에 안장",
      "imageUrl": "https://flexible.img.hani.co.kr/flexible/normal/616/429/imgdb/original/2025/0420/20250420501337.webp",
      "likeCount": 1,
      "scrapCount": 1
    }
  ]
}`


### 완료 작업:
ArticleController에 GET 관련 기사 (헤드라인, 사진, 좋아요수, 스크랩 수) api 추가
NewsService에 getRelatedNews() 메서드 구현

### api 테스트
<img width="1160" alt="관련 기사 (헤드라인, 사진, 좋아요수, 스크랩 수)" src="https://github.com/user-attachments/assets/5c19aede-4d6d-47a4-9e21-08e5f3a521f5" />
