### PR TITLE
기사 헤드라인, 기사 사진 API 추가

### DIFF
--- a/src/main/java/team/backend/curio/controller/ArticleController.java
+++ b/src/main/java/team/backend/curio/controller/ArticleController.java
@@ -1,0 +1,33 @@
+package team.backend.curio.controller;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import team.backend.curio.dto.NewsDTO.NewsResponseDto;
+import team.backend.curio.dto.NewsDTO.RelatedNewsResponse;
+import team.backend.curio.service.NewsService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/articles")  // api/articles로 경로 설정
+@RequiredArgsConstructor
+
+public class ArticleController {
+    private final NewsService newsService;  // NewsService 주입
+
+    // 특정 뉴스의 관련 뉴스 조회
+    @GetMapping("/{articleId}/related")
+    public ResponseEntity<List<RelatedNewsResponse>> getRelatedNews(@PathVariable Long articleId) {
+        List<RelatedNewsResponse> relatedNews = newsService.getRelatedNews(articleId);
+        return ResponseEntity.ok(relatedNews);
+    }
+
+    // 특정 뉴스의 헤드라인과 이미지 URL 조회
+    @GetMapping("/{articleId}/headline")
+    public ResponseEntity<NewsResponseDto> getArticleHeadline(@PathVariable Long articleId) {
+        NewsResponseDto newsResponse = newsService.getArticleHeadline(articleId); // NewsService에서 데이터 가져오기
+        return ResponseEntity.ok(newsResponse); // 헤드라인과 이미지 URL 반환
+    }
+}

--- a/src/main/java/team/backend/curio/dto/NewsDTO/NewsResponseDto.java
+++ b/src/main/java/team/backend/curio/dto/NewsDTO/NewsResponseDto.java
@@ -1,4 +1,5 @@
 package team.backend.curio.dto.NewsDTO;
+
 import lombok.Getter;
 import lombok.Setter;
 import team.backend.curio.domain.News;
@@ -6,6 +7,7 @@ import team.backend.curio.domain.News;
 @Getter
 @Setter
 public class NewsResponseDto {
+
     private String title;
     private String content;
     private String imageUrl;
@@ -17,4 +19,9 @@ public class NewsResponseDto {
         this.imageUrl = news.getImageUrl();  // 이미지 URL 추가
     }
 
+    // 새로운 생성자 (title과 imageUrl을 받는 생성자 추가)
+    public NewsResponseDto(String title, String imageUrl) {
+        this.title = title;
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/team/backend/curio/dto/NewsDTO/RelatedNewsResponse.java
+++ b/src/main/java/team/backend/curio/dto/NewsDTO/RelatedNewsResponse.java
@@ -1,0 +1,18 @@
+package team.backend.curio.dto.NewsDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor // 생성자를 자동으로 만들어주는 Lombok 어노테이션
+
+public class RelatedNewsResponse {
+
+    private String title;          // 기사 제목 (헤드라인)
+    private String imageUrl;       // 기사 이미지 URL
+    private int likeCount;         // 좋아요 수
+    private int saveCount;         // 스크랩 수
+
+}

--- a/src/main/java/team/backend/curio/repository/NewsRepository.java
+++ b/src/main/java/team/backend/curio/repository/NewsRepository.java
@@ -2,6 +2,7 @@ package team.backend.curio.repository;
 
 import team.backend.curio.domain.News;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface NewsRepository extends JpaRepository<News, Long> {
@@ -13,4 +14,13 @@ public interface NewsRepository extends JpaRepository<News, Long> {
 
     // 좋아요 수로 내림차순 정렬, 같으면 최신순으로 정렬
     List<News> findTop4ByOrderByLikeCountDescCreatedAtDesc();
+
+    // 특정 뉴스의 카테고리 조회
+    @Query("SELECT n.category FROM News n WHERE n.newsId = :articleId")
+    String findCategoryById(Long articleId);
+
+    // 해당 카테고리로 관련 뉴스 조회
+    @Query("SELECT n FROM News n WHERE n.category = :category")
+    List<News> findRelatedNewsByCategory(String category);
+
 }

--- a/src/main/java/team/backend/curio/service/NewsService.java
+++ b/src/main/java/team/backend/curio/service/NewsService.java
@@ -6,8 +6,11 @@ import team.backend.curio.domain.News;
 import team.backend.curio.domain.users;
 import team.backend.curio.dto.NewsDTO.InterestNewsResponseDto;
 import team.backend.curio.dto.NewsDTO.NewsResponseDto;
+import team.backend.curio.dto.NewsDTO.RelatedNewsResponse;
 import team.backend.curio.repository.NewsRepository;
 import team.backend.curio.repository.UserRepository;
+
+
 
 import java.util.ArrayList;
 import java.util.List;
@@ -63,6 +66,33 @@ public class NewsService {
         newsRepository.saveAll(newsList);  // 여러 개의 뉴스 저장
     }
 
+    //특정 뉴스의 관련 뉴스 조회
+    public List<RelatedNewsResponse> getRelatedNews(Long articleId){
+        // 먼저 해당 기사 id로 카테고리조회
+        String category=newsRepository.findCategoryById(articleId);
 
+        // 해당 카테고리로 관련 기사들을 조회
+        List<News> relatedNews = newsRepository.findByCategory(category);
+
+        // 관련 뉴스 데이터를 DTO로 변환하여 반환
+        return relatedNews.stream()
+                .map(news -> new RelatedNewsResponse(
+                        news.getTitle(),
+                        news.getImageUrl(),
+                        news.getLikeCount(),
+                        news.getSaveCount()
+                ))
+                .collect(Collectors.toList()); // Stream을 List로 변환
+    }
+
+    // 기사 헤드라인과 이미지 URL 조회
+    public NewsResponseDto getArticleHeadline(Long articleId) {
+        // 해당 기사 조회
+        News news = newsRepository.findById(articleId)
+                .orElseThrow(() -> new IllegalArgumentException("Article not found"));
+
+        // 헤드라인과 이미지 URL 반환
+        return new NewsResponseDto(news.getTitle(), news.getImageUrl());
+    }
 }
 


### PR DESCRIPTION
###이슈 설명:
/api/articles/{article_id}/headline 경로의 GET API가 구현되었습니다.
이 API는 특정 기사에 대한 헤드라인과 이미지를 조회하는 기능을 제공합니다.
특정 기사(articleId)의 제목과 이미지 URL을 반환합니다.

###요청 예시:

###응답 예시:
`{
  "id": 123,
  "headline": "AI가 뽑은 오늘의 뉴스",
  "imageurl": "https://news.example.com/images/123.jpg"
}`

###완료 작업:
ArticleController에 GET 기사 헤드라인 및 이미지 조회 API 추가
/api/articles/{article_id}/headline 경로에서 특정 기사(articleId)의 제목(헤드라인)과 이미지 URL을 반환하는 GET API 구현

반환되는 데이터는 기사 제목과 이미지 URL 포함

###api 테스트
<img width="1159" alt="기사 헤드라인, 기사 이미지" src="https://github.com/user-attachments/assets/efe60baf-e428-4750-8194-d9650df0001c" />
