### PR TITLE
커스텀 설정 api 구현

### DIFF
--- a/src/main/java/team/backend/curio/controller/UserController.java
+++ b/src/main/java/team/backend/curio/controller/UserController.java
@@ -5,6 +5,7 @@ import team.backend.curio.domain.News;
 import team.backend.curio.dto.NewsDTO.InterestNewsResponseDto;
 import team.backend.curio.dto.NewsDTO.NewsResponseDto;
 import team.backend.curio.dto.UserCreateDto;
+import team.backend.curio.dto.CustomSettingDto;
 import team.backend.curio.dto.UserDTO.UserInterestResponse;
 import team.backend.curio.service.UserService;
 import team.backend.curio.service.NewsService;
@@ -79,5 +80,11 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "사용자의 커스텀 설정 조회 (요약 선호도)")
+    @GetMapping("/{userId}/custom")
+    public ResponseEntity<CustomSettingDto> getUserCustomSettings(@PathVariable Long userId){
+        CustomSettingDto customSettingDto= userService.getUserCustomSettings(userId); // 유저 서비스 호출하여 데이터 가져오기
+        return ResponseEntity.ok(customSettingDto);
+    }
 }
 

--- a/src/main/java/team/backend/curio/controller/UserController.java
+++ b/src/main/java/team/backend/curio/controller/UserController.java
@@ -86,5 +86,19 @@ public class UserController {
         CustomSettingDto customSettingDto= userService.getUserCustomSettings(userId); // 유저 서비스 호출하여 데이터 가져오기
         return ResponseEntity.ok(customSettingDto);
     }
+
+    // summaryPreference 값을 short, medium, long으로 매핑하는 함수
+    private String mapSummaryType(int summaryPreference) {
+        switch (summaryPreference) {
+            case 1:
+                return "short";
+            case 2:
+                return "medium";
+            case 3:
+                return "long";
+            default:
+                return "medium";  // 기본값은 "medium"으로 설정
+        }
+    }
 }
 

--- a/src/main/java/team/backend/curio/domain/users.java
+++ b/src/main/java/team/backend/curio/domain/users.java
@@ -25,7 +25,7 @@ public class users {
     private String email; //소셜로그인에 사용된 이메일
 
     @Column(name = "social_type")
-    private int socialType; // 카카오, 구글
+    private Integer socialType; // 카카오, 구글
 
     @Column(name = "newsletter_email")
     private String newsletterEmail; //뉴스레터 받을 이메일

--- a/src/main/java/team/backend/curio/dto/CustomSettingDto.java
+++ b/src/main/java/team/backend/curio/dto/CustomSettingDto.java
@@ -1,0 +1,17 @@
+package team.backend.curio.dto;  // 패키지 경로 수정
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+
+public class CustomSettingDto {
+
+    private int summaryPreference; // 요약 선호도 (1=짧음, 2=보통, 3=김)
+
+    public CustomSettingDto(int summaryPreference){
+        this.summaryPreference=summaryPreference;
+    }
+}

--- a/src/main/java/team/backend/curio/service/UserService.java
+++ b/src/main/java/team/backend/curio/service/UserService.java
@@ -3,6 +3,7 @@ package team.backend.curio.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import team.backend.curio.domain.users;
+import team.backend.curio.dto.CustomSettingDto;
 import team.backend.curio.dto.UserCreateDto;
 import team.backend.curio.dto.UserDTO.UserInterestResponse;
 import team.backend.curio.dto.UserResponseDto;
@@ -72,6 +73,30 @@ public class UserService {
         userRepository.save(user);
 
         return new UserInterestResponse(interests);
+    }
+
+
+    // 사용자의 커스텀 설정에서 요약 선호도 반환
+    public CustomSettingDto getUserCustomSettings(Long userId) {
+        users user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        // 사용자가 설정한 요약 선호도 반환
+        return new CustomSettingDto(user.getSummaryPreference());
+    }
+
+    // 사용자의 커스텀 설정에서 요약 선호도 수정
+    public CustomSettingDto updateUserCustomSettings(Long userId, CustomSettingDto customSettingDto) {
+        users user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        // 요약 선호도 수정
+        user.setSummaryPreference(customSettingDto.getSummaryPreference());
+
+        userRepository.save(user);
+
+        // 수정된 요약 선호도 반환
+        return new CustomSettingDto(user.getSummaryPreference());
     }
 }
 


### PR DESCRIPTION
###이슈 설명:
/api/users/{userId}/custom 경로의 GET API 기능이 구현되었습니다.

이 API는 사용자의 선호도 정보를 반환하는 기능을 합니다. 반환되는 정보는 사용자가 설정한 요약 선호도(summary_preference)로, 요약 길이에 대한 사용자의 선호도가 포함됩니다.

summary_preference 값은 다음과 같습니다:
1: 짧은 요약 (short)
2: 중간 길이의 요약 (medium)
3: 긴 요약 (long)

만약 해당 사용자가 설정하지 않은 경우 기본값으로 2(중간 길이)를 반환합니다.
summary_preference: 사용자가 설정한 요약 길이 선호도를 반환합니다.

###요청 예시:
`{
"summaryPreference": 2  // 요약 선호도 (1: 짧음, 2: 보통, 3: 김)
}
`
###응답 예시:
`{
  "summaryPreference": 2,
  "summary_type": "medium"
}`

###완료 작업:
/api/users/{user_id}/custom API 구현
UserService에 커스텀 설정 조회 메서드 추가

###api 테스트
<img width="1159" alt="커스텀 설정" src="https://github.com/user-attachments/assets/f942f3c6-f1ef-40cf-b6d4-eb94bc30c3f1" />
