### PR TITLE
fix: 커스텀 설정 API 관련 수정

### DIFF
--- a/src/main/java/team/backend/curio/controller/UserController.java
+++ b/src/main/java/team/backend/curio/controller/UserController.java
@@ -87,7 +87,7 @@ public class UserController {
         return ResponseEntity.ok(customSettingDto);
     }
 
-    // summaryPreference 값을 short, medium, long으로 매핑하는 함수
+    // summaryPreference 값을 short, medium, long으로 매핑하는 함수 추가
     private String mapSummaryType(int summaryPreference) {
         switch (summaryPreference) {
             case 1:
@@ -97,7 +97,7 @@ public class UserController {
             case 3:
                 return "long";
             default:
-                return "medium";  // 기본값은 "medium"으로 설정
+                return "medium"; // 기본값은 "medium"으로 설정
         }
     }
 }


### PR DESCRIPTION
커스텀 설정 API 수정 (summaryPreference 값 자동 매핑 추가)
기존에 summaryPreference 값은 숫자(1, 2, 3)로만 설정되어 있었습니다.
summaryPreference 값에 따라 자동으로 "short", "medium", "long" 값을 반환하도록 수정되었습니다.

###api테스트
<img width="1161" alt="유저 커스텀 설정" src="https://github.com/user-attachments/assets/d9a9ed0d-737e-4e93-83ec-45acfae394fd" />
