### PR TITLE
사용자 닉네임, 프로필 불러오기 API 구현

### DIFF
--- a/src/main/java/team/backend/curio/controller/UserController.java
+++ b/src/main/java/team/backend/curio/controller/UserController.java
@@ -1,6 +1,7 @@
 package team.backend.curio.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import team.backend.curio.domain.users;
 import team.backend.curio.domain.News;
 import team.backend.curio.dto.NewsDTO.InterestNewsResponseDto;
 import team.backend.curio.dto.NewsDTO.NewsResponseDto;
@@ -100,5 +101,23 @@ public class UserController {
                 return "medium"; // 기본값은 "medium"으로 설정
         }
     }
+
+    // 사용자 프로필 조회 (닉네임과 프로필 사진)
+    @Operation(summary = "사용자 프로필 조회 (닉네임, 프로필 사진)")
+    @GetMapping("/{userId}/profile")
+    public ResponseEntity<?> getUserProfile(@PathVariable Long userId) {
+        // 사용자 조회
+        users user = userService.getUserById(userId); // userService에서 사용자 정보 조회
+        if (user == null) {
+            return ResponseEntity.status(404).body("User not found");
+        }
+        // 닉네임과 프로필 이미지 URL을 응답
+        return ResponseEntity.ok(new Object() {
+            public final String nickname = user.getNickname();
+            public final String profileImageUrl = user.getProfileImageUrl();
+        });
+    }
+
+
 }
 

--- a/src/main/java/team/backend/curio/domain/users.java
+++ b/src/main/java/team/backend/curio/domain/users.java
@@ -42,4 +42,6 @@ public class users {
     private String interest3;
     private String interest4;
 
+    // **프로필 사진 URL 추가**
+    private String profileImageUrl;  // 프로필 사진 URL 필드 추가
 }

--- a/src/main/java/team/backend/curio/dto/UserResponseDto.java
+++ b/src/main/java/team/backend/curio/dto/UserResponseDto.java
@@ -9,4 +9,17 @@ public class UserResponseDto {
     private Long userId;  // 유저 ID
     private String nickname;  // 닉네임
     private String email;  // 이메일
+    private String profileImageUrl;  // 프로필 사진 URL 추가
+
+    // 기존에 정의된 기본 생성자가 필요한 경우
+    public UserResponseDto()
+    {
+        // 기본 생성자
+    }
+
+    // 기본 생성자
+    public UserResponseDto(String nickname, String profileImageUrl) {
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+    }
 }

--- a/src/main/java/team/backend/curio/service/UserService.java
+++ b/src/main/java/team/backend/curio/service/UserService.java
@@ -98,5 +98,11 @@ public class UserService {
         // 수정된 요약 선호도 반환
         return new CustomSettingDto(user.getSummaryPreference());
     }
+
+    // **사용자의 닉네임과 프로필 사진 URL 반환**
+    public users getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+    }
 }
 


### PR DESCRIPTION
### 이슈설명
마이페이지에 닉네임과 프로필 사진 불러오는 api를 구현했습니다.

### 응답예시
`{
  "nickname": "chaeyoung",
  "profileImageUrl": "http://example.com/path/to/profile/image.jpg"
}`

### api테스트
<img width="1164" alt="마이페이지 닉네임, 프로필사진 불러오기" src="https://github.com/user-attachments/assets/9f17ef0c-9c0b-4d3e-9bf3-b935a10b56fb" />
