### PR TITLE
마이페이지 설정 수정(요약 선호도, 이메일, 카테고리, 폰트크기) api 구현

### DIFF
--- a/src/main/java/team/backend/curio/controller/UserController.java
+++ b/src/main/java/team/backend/curio/controller/UserController.java
@@ -88,17 +88,28 @@ public class UserController {
         return ResponseEntity.ok(customSettingDto);
     }
 
+    // 사용자 설정 전체 수정
+    @Operation(summary = "사용자의 커스텀 설정 전체 수정 (요약, 이메일, 카테고리, 폰트크기)")
+    @PatchMapping("/{userId}/settings")
+    public ResponseEntity<CustomSettingDto> updateUserCustomSettings(
+            @PathVariable Long userId,
+            @RequestBody CustomSettingDto customSettingDto
+    ) {
+        try {
+            CustomSettingDto updated = userService.updateUserCustomSettings(userId, customSettingDto);
+            return ResponseEntity.ok(updated);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        }
+    }
+
     // summaryPreference 값을 short, medium, long으로 매핑하는 함수 추가
     private String mapSummaryType(int summaryPreference) {
         switch (summaryPreference) {
-            case 1:
-                return "short";
-            case 2:
-                return "medium";
-            case 3:
-                return "long";
-            default:
-                return "medium"; // 기본값은 "medium"으로 설정
+            case 1: return "short";
+            case 2: return "medium";
+            case 3: return "long";
+            default: return "medium"; // 기본값은 "medium"으로 설정
         }
     }
 
@@ -117,7 +128,5 @@ public class UserController {
             public final String profileImageUrl = user.getProfileImageUrl();
         });
     }
-
-
 }
 

--- a/src/main/java/team/backend/curio/domain/users.java
+++ b/src/main/java/team/backend/curio/domain/users.java
@@ -44,4 +44,7 @@ public class users {
 
     // **프로필 사진 URL 추가**
     private String profileImageUrl;  // 프로필 사진 URL 필드 추가
+
+    private String fontSize;
+
 }

--- a/src/main/java/team/backend/curio/dto/CustomSettingDto.java
+++ b/src/main/java/team/backend/curio/dto/CustomSettingDto.java
@@ -3,6 +3,8 @@ package team.backend.curio.dto;  // 패키지 경로 수정
 
 import lombok.Getter;
 import lombok.Setter;
+import java.util.List;
+
 
 @Getter
 @Setter
@@ -12,23 +14,36 @@ public class CustomSettingDto {
     private int summaryPreference; // 요약 선호도 (1=짧음, 2=보통, 3=김)
     private String summaryType;    // 요약 타입 (short, medium, long)
 
+    private String newsletterEmail;
+    private List<String> categories;     // interest 1~4에 매핑
+    private String fontSize;           // 글자 크기 (SMALL, MEDIUM, LARGE)
+
     // 생성자 수정: summaryPreference 값에 따라 summaryType을 설정
     public CustomSettingDto(int summaryPreference) {
         this.summaryPreference = summaryPreference;
         this.summaryType = mapSummaryType(summaryPreference);  // summaryType을 매핑
     }
 
+    public CustomSettingDto()
+    {
+
+    }
+    // 오버로드 생성자
+    public CustomSettingDto(int summaryPreference, String newsletterEmail, List<String> categories, String fontSize) {
+        this.summaryPreference = summaryPreference;
+        this.summaryType = mapSummaryType(summaryPreference);
+        this.newsletterEmail = newsletterEmail;
+        this.categories = categories;
+        this.fontSize = fontSize;
+    }
+
     // summaryPreference 값을 받아 summaryType을 반환하는 메서드
     private String mapSummaryType(int summaryPreference) {
         switch (summaryPreference) {
-            case 1:
-                return "short";  // 짧음
-            case 2:
-                return "medium"; // 보통
-            case 3:
-                return "long";   // 길음
-            default:
-                return "medium"; // 기본값은 "medium"
+            case 1: return "short";  // 짧음
+            case 2: return "medium"; // 보통
+            case 3: return "long";   // 길음
+            default: return "medium"; // 기본값은 "medium"
         }
     }
 }

--- a/src/main/java/team/backend/curio/service/UserService.java
+++ b/src/main/java/team/backend/curio/service/UserService.java
@@ -85,7 +85,8 @@ public class UserService {
         return new CustomSettingDto(user.getSummaryPreference());
     }
 
-    // 사용자의 커스텀 설정에서 요약 선호도 수정
+
+    // 사용자의 커스텀 설정에서 요약 선호도 및 기타 설정값 수정
     public CustomSettingDto updateUserCustomSettings(Long userId, CustomSettingDto customSettingDto) {
         users user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
@@ -93,10 +94,29 @@ public class UserService {
         // 요약 선호도 수정
         user.setSummaryPreference(customSettingDto.getSummaryPreference());
 
+        // 수신 이메일 저장
+        user.setNewsletterEmail(customSettingDto.getNewsletterEmail());
+
+        // 폰트 크기 저장 (String으로)
+        user.setFontSize(customSettingDto.getFontSize());
+
+        // 카테고리 리스트 → interest1~4에 분배
+        List<String> categories = customSettingDto.getCategories();
+        if (categories != null) {
+            if (categories.size() > 0) user.setInterest1(categories.get(0));
+            if (categories.size() > 1) user.setInterest2(categories.get(1));
+            if (categories.size() > 2) user.setInterest3(categories.get(2));
+            if (categories.size() > 3) user.setInterest4(categories.get(3));
+        }
+
         userRepository.save(user);
 
-        // 수정된 요약 선호도 반환
-        return new CustomSettingDto(user.getSummaryPreference());
+        return new CustomSettingDto(
+                user.getSummaryPreference(),
+                user.getNewsletterEmail(),
+                List.of(user.getInterest1(), user.getInterest2(), user.getInterest3(), user.getInterest4()),
+                user.getFontSize()
+        );
     }
 
     // **사용자의 닉네임과 프로필 사진 URL 반환**


### PR DESCRIPTION
### 이슈 설명
이 API는 사용자의 마이페이지 설정을 수정하는 기능을 제공합니다. 사용자는 다음 설정을 변경할 수 있습니다. 클라이언트(프론트엔드)가 사용자 입력을 받아 서버로 보내는 형태입니다

글자 크기 (글자 크기 설정) 요약 정도 (짧음, 보통, 길음) 수신 이메일 (수신 이메일 설정) 카테고리 (관심 카테고리 설정)

### 요청 예시
`{
  "summaryPreference": 3,
  "newsletterEmail": "sample@naver.com",
  "categories": ["정치", "경제", "IT", "과학"],
  "fontSize": "MEDIUM"
}`

### 응답 예시
`{
	"summaryPreference": 3,
  "summaryType": "long",
  "newsletterEmail": "sample@naver.com",
  "categories": [
        "정치",
        "경제",
        "IT",
        "과학"
    ],
   "fontSize": "MEDIUM"
}`

### api 테스트
<img width="1158" alt="마이페이지 설정 수정" src="https://github.com/user-attachments/assets/b14e42fd-5eb7-4586-9414-8d6ffa1f7177" />
