### PR TITLE
feat: 홈화면 뉴스레터 신청 api

### DIFF
--- a/src/main/java/team/backend/curio/controller/UserController.java
+++ b/src/main/java/team/backend/curio/controller/UserController.java
@@ -128,5 +128,27 @@ public class UserController {
             public final String profile_image_url = user.getProfile_image_url();
         });
     }
+
+    // 뉴스레터 수신 여부 설정 (가입된 회원만)
+    @Operation(summary = "뉴스레터 신청")
+    @PatchMapping("/{userId}/newsletter/subscribe")
+    public ResponseEntity<String> updateNewsletterSubscription(
+            @PathVariable Long userId, @RequestParam boolean subscribe) {
+
+        try {
+            // 유효한 사용자인지 확인
+            users user = userService.getUserById(userId); // 유저 정보 조회
+
+            // 유저가 가입된 사용자라면 뉴스레터 상태를 업데이트
+            user.setNewsletterStatus(subscribe ? 1 : 0); // 1: 구독, 0: 구독 취소
+            userService.save(user); // DB에 저장
+
+            // 성공적으로 업데이트한 후 응답
+            return ResponseEntity.ok("뉴스레터 신청 상태가 업데이트되었습니다.");
+        } catch (IllegalArgumentException e) {
+            // 유저가 존재하지 않으면 404 반환
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("사용자를 찾을 수 없습니다.");
+        }
+    }
 }
 

--- a/src/main/java/team/backend/curio/domain/users.java
+++ b/src/main/java/team/backend/curio/domain/users.java
@@ -47,4 +47,7 @@ public class users {
     private String fontSize;
   
     private String profile_image_url;  // 프로필 사진 URL 필드 추가
+
+    @Column(name = "newsletter_status", nullable = false, columnDefinition = "int default 0") // 0이면 구독 안함, 1이면 구독함
+    private int newsletterStatus; // 뉴스레터 구독 상태 (0: 구독 안함, 1: 구독함)
 }

--- a/src/main/java/team/backend/curio/repository/UserRepository.java
+++ b/src/main/java/team/backend/curio/repository/UserRepository.java
@@ -2,8 +2,13 @@ package team.backend.curio.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.backend.curio.domain.users;
+import java.util.List;
+
 
 public interface UserRepository extends JpaRepository<users, Long> {
     // 추가적인 쿼리 메서드가 필요하면 여기에 작성
-}
 
+    // 뉴스레터 신청 상태가 1이고, 수신 이메일이 설정된 사용자 조회
+    List<users> findByNewsletterStatusAndNewsletterEmailNotNull(int status);
+
+}

--- a/src/main/java/team/backend/curio/service/UserService.java
+++ b/src/main/java/team/backend/curio/service/UserService.java
@@ -119,10 +119,27 @@ public class UserService {
         );
     }
 
-    // **사용자의 닉네임과 프로필 사진 URL 반환**
+    // 사용자의 닉네임과 프로필 사진 URL 반환
     public users getUserById(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
     }
-}
 
+    // 사용자 정보 저장
+    public void save(users user) {
+        userRepository.save(user);  // user 객체를 DB에 저장
+    }
+
+    // 뉴스레터 신청 상태 업데이트
+    public void updateNewsletterStatus(Long userId, boolean subscribe) {
+        // 사용자 조회
+        users user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // 뉴스레터 상태 업데이트 (1: 신청, 0: 취소)
+        user.setNewsletterStatus(subscribe ? 1 : 0);
+
+        // 변경된 사용자 정보 저장
+        save(user);
+    }
+}


### PR DESCRIPTION
### 이슈 설명
홈화면에서 뉴스레터 신청하면 상태값을 변경하는 /api/users/{user_id}/newsletter/subscribe api를 구현했습니다.
수신 설정
true: 1
false: 0

### 요청값
`{
  "subscribe": true // true: 신청, false: 취소
}`

### 응답값
`{
  "message": "뉴스레터 신청 상태가 업데이트되었습니다.",
  "status": 1  // 1: 신청됨, 0: 취소됨
}`

### api테스트
<img width="1157" alt="홈화면 뉴스레터 신청" src="https://github.com/user-attachments/assets/d91482ec-0bc3-4db6-821c-a80e227b187e" />
