### PR TITLE
feat: 유저 탈퇴 api 구현

### DIFF
--- a/src/main/java/team/backend/curio/controller/UserController.java
+++ b/src/main/java/team/backend/curio/controller/UserController.java
@@ -193,5 +193,15 @@ public class UserController {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body("사용자를 찾을 수 없습니다.");
         }
     }
+
+    @DeleteMapping("/{userId}/delete")
+    public ResponseEntity<String> deleteUser(@PathVariable Long userId) {
+        try {
+            userService.deleteUser(userId);  // 유저 삭제 서비스 호출
+            return ResponseEntity.status(HttpStatus.OK).body("User deleted successfully");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Error deleting user");
+        }
+    }
 }
 

--- a/src/main/java/team/backend/curio/domain/users.java
+++ b/src/main/java/team/backend/curio/domain/users.java
@@ -42,12 +42,12 @@ public class users {
     private String interest3;
     private String interest4;
 
-    // **프로필 사진 URL 추가**
-
     private String fontSize;
   
     private String profile_image_url;  // 프로필 사진 URL 필드 추가
 
     @Column(name = "newsletter_status", nullable = false, columnDefinition = "int default 0") // 0이면 구독 안함, 1이면 구독함
     private int newsletterStatus; // 뉴스레터 구독 상태 (0: 구독 안함, 1: 구독함)
+
+
 }

--- a/src/main/java/team/backend/curio/service/UserService.java
+++ b/src/main/java/team/backend/curio/service/UserService.java
@@ -152,4 +152,16 @@ public class UserService {
         return userRepository.findByNewsletterStatusAndNewsletterEmailNotNull(1); // 1은 뉴스레터 구독 상태
     }
 
+    public String deleteUser(Long userId){
+        //유저가 존재하는지 확인
+        users user=userRepository.findById(userId).orElse(null);
+        if(user ==null){
+            return "User not found"; //유저가 없다면 메시지 반환
+        }
+
+        //유저 삭제
+        userRepository.delete(user);
+
+        return "User가 성공적으로 삭제되었습니다."; //성공 메세지 반환
+    }
 }


### PR DESCRIPTION
### 이슈 설명
user 탈퇴 시 유저 테이블에서 삭제되는 /api/users/{user_id}/delete api가 구현되었습니다.

### 요청값

### 응답값
{
  "message": "User deleted successfully"
}

### api 테스트
<img width="1158" alt="유저 탈퇴하기" src="https://github.com/user-attachments/assets/efb114de-446d-4964-b365-70daffe3bcb2" />
