### PR TITLE
feat: 요약정도에 맞는 기사글 불러오기

### DIFF
--- a/src/main/java/team/backend/curio/controller/ArticleController.java
+++ b/src/main/java/team/backend/curio/controller/ArticleController.java
@@ -4,13 +4,17 @@ package team.backend.curio.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import team.backend.curio.domain.News;
 import team.backend.curio.dto.NewsDTO.NewsResponseDto;
 import team.backend.curio.dto.NewsDTO.RelatedNewsResponse;
+import team.backend.curio.dto.NewsDTO.NewsSummaryResponseDto;
 import team.backend.curio.service.NewsService;
 
 import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
 
 @RestController
 @RequestMapping("/articles")  // api/articles로 경로 설정
@@ -46,5 +50,24 @@ public class ArticleController {
     @GetMapping("/list")
     public List<News> getNewsList() {
         return newsService.getAllNews();
+    }
+
+    // 뉴스 요약 API
+    @Operation(summary = "요약 정도에 따라 뉴스 요약 반환")
+    @GetMapping("/{articleId}/summary")
+    public ResponseEntity<?> getArticleSummary(
+            @PathVariable Long articleId,
+            @RequestParam String type) {
+
+        try {
+            NewsSummaryResponseDto response = newsService.getSummaryByType(articleId, type);
+            return ResponseEntity.ok(response);
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", e.getMessage()));
+        }
     }
 }

--- a/src/main/java/team/backend/curio/dto/NewsDTO/NewsSummaryResponseDto.java
+++ b/src/main/java/team/backend/curio/dto/NewsDTO/NewsSummaryResponseDto.java
@@ -1,0 +1,14 @@
+package team.backend.curio.dto.NewsDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NewsSummaryResponseDto {
+    private Long newsId;
+    private String title;
+    private String summaryType;
+    private String summary;
+
+}

--- a/src/main/java/team/backend/curio/service/NewsService.java
+++ b/src/main/java/team/backend/curio/service/NewsService.java
@@ -7,6 +7,7 @@ import team.backend.curio.domain.users;
 import team.backend.curio.dto.NewsDTO.InterestNewsResponseDto;
 import team.backend.curio.dto.NewsDTO.NewsResponseDto;
 import team.backend.curio.dto.NewsDTO.RelatedNewsResponse;
+import team.backend.curio.dto.NewsDTO.NewsSummaryResponseDto;
 import team.backend.curio.repository.NewsRepository;
 import team.backend.curio.repository.UserRepository;
 
@@ -93,6 +94,37 @@ public class NewsService {
 
         // 헤드라인과 이미지 URL 반환
         return new NewsResponseDto(news.getTitle(), news.getImageUrl());
+    }
+
+    // 뉴스 요약 조회 기능 추가
+    public NewsSummaryResponseDto getSummaryByType(Long articleId, String type) {
+        News news = newsRepository.findById(articleId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 기사를 찾을 수 없습니다."));
+
+        String summary;
+
+        // 요청된 요약 타입에 따라 필드를 선택
+        switch (type.toLowerCase()) {
+            case "short":
+                summary = news.getSummaryShort();
+                break;
+            case "medium":
+                summary = news.getSummaryMedium();
+                break;
+            case "long":
+                summary = news.getSummaryLong();
+                break;
+            default:
+                throw new IllegalArgumentException("요약 타입은 short, medium, long 중 하나여야 합니다.");
+        }
+
+        // 요약이 null이거나 빈 문자열이면 예외 발생
+        if (summary == null || summary.isBlank()) {
+            throw new IllegalArgumentException("요약 내용이 존재하지 않습니다.");
+        }
+
+        // 응답 DTO 생성하여 반환
+        return new NewsSummaryResponseDto(news.getNewsId(), news.getTitle(), type, summary);
     }
 }
 


### PR DESCRIPTION
### 이슈설명
뉴스 기사 화면에서 사용자가 선택한 요약 정도에 맞는 기사글을 불러오는 /api/articles/{article_id}/summary api가 구현되었습니다.
뉴스 테이블에 

클라이언트는 사용자의 입력(요약 정도 선택)을 기반으로 서버에 요청을 보내고,
서버는 해당 뉴스 기사 ID와 요청된 요약 타입에 맞는 내용을 응답합니다.

### 요청값
GET /api/articles/5/summary?type=medium

### 응답값
`{
  "article_id": 5,
  "title": "[속보] 내란·김건희 특검법, 국회 법사위 통과",
  "summary_type": "medium",
  "summary": "요약된 기사 내용입니다."
}`

### api 테스트
<img width="1156" alt="요약 정도에 맞는 기사 불러오기" src="https://github.com/user-attachments/assets/98c30da8-5162-4eac-82e4-a020d258dc4a" />
