### PR TITLE
"feat: 관련기사 좋아요순 상위 4개 출력"

### DIFF
--- a/src/main/java/team/backend/curio/repository/NewsRepository.java
+++ b/src/main/java/team/backend/curio/repository/NewsRepository.java
@@ -3,6 +3,8 @@ package team.backend.curio.repository;
 import team.backend.curio.domain.News;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface NewsRepository extends JpaRepository<News, Long>, NewsSearchRepository {
@@ -21,8 +23,7 @@ public interface NewsRepository extends JpaRepository<News, Long>, NewsSearchRep
     String findCategoryById(Long articleId);
 
     // 해당 카테고리로 관련 뉴스 조회
-    @Query("SELECT n FROM News n WHERE n.category = :category")
-    List<News> findRelatedNewsByCategory(String category);
-
+    @Query(value="SELECT * FROM News WHERE category = :category AND news_id <> :excludeId ORDER BY like_count DESC LIMIT 4", nativeQuery=true)
+    List<News> findTop4RelatedNewsByCategory(@Param("category") String category, @Param("excludeId") Long excludeId);
 
 }

--- a/src/main/java/team/backend/curio/service/NewsService.java
+++ b/src/main/java/team/backend/curio/service/NewsService.java
@@ -78,7 +78,7 @@ public class NewsService {
         String category=newsRepository.findCategoryById(articleId);
 
         // 해당 카테고리로 관련 기사들을 조회
-        List<News> relatedNews = newsRepository.findByCategory(category);
+        List<News> relatedNews = newsRepository.findTop4RelatedNewsByCategory(category,articleId);
 
         // 관련 뉴스 데이터를 DTO로 변환하여 반환
         return relatedNews.stream()


### PR DESCRIPTION
### 이슈 설명
관련기사 출력 좋아요순 상위4개 출력으로 수정되었습니다.

### 응답값
`{
  "article_id": 123,
  "related_articles": [
    {
      "id": 456,
      "headline": "AI 뉴스 요약 기술의 미래",
      "imageurl": "https://news.example.com/images/456.jpg",
      "likeCount": 1,
      "scrapCount": 1
    },
    {
      "id": 789,
      "headline": "뉴스 소비 방식의 변화",
      "imageurl": "https://news.example.com/images/789.jpg",
      "likeCount": 1,
      "scrapCount": 1
    },
    { "title": "‘가평전투’ 참전 캐나다 용사 유해, 부산 유엔기념공원에 안장",
      "imageUrl": "https://flexible.img.hani.co.kr/flexible/normal/616/429/imgdb/original/2025/0420/20250420501337.webp",
      "likeCount": 1,
      "scrapCount": 1
     }
  ]
}`

### api 테스트
<img width="1160" alt="관련기사 좋아요순 상위 4개 출력" src="https://github.com/user-attachments/assets/acc92a54-465d-4fe3-93ac-110460c45e59" />

