### PR TITLE
fix:검색정렬 swagger sort 숨김

### DIFF
--- a/src/main/java/team/backend/curio/controller/SearchController.java
+++ b/src/main/java/team/backend/curio/controller/SearchController.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 import team.backend.curio.dto.NewsDTO.SearchNewsResponseDto;
 import team.backend.curio.service.NewsService;
+import io.swagger.v3.oas.annotations.Parameter;
 
 import java.util.List;
 import java.util.Arrays;
@@ -23,7 +24,7 @@ public class SearchController {
     public Page<SearchNewsResponseDto> search(
             @RequestParam String query,
             @RequestParam String type,
-            Pageable pageable
+            @Parameter(hidden = true) Pageable pageable
     ) {
         if (type.equalsIgnoreCase("news")) {
             List<String> keywords = Arrays.stream(query.split("\\s+"))


### PR DESCRIPTION
### 이슈 설명
swagger에 sort는 백엔드에서 좋아요순 내림차순 정렬로 하드코딩해두었기 때문에 swagger에서 sort를 줄 필요 없이 sort숨김 처리로 코드를 수정했습니다.