### PR TITLE
feat: 검색정렬 login-token 문제 해결

### DIFF
--- a/src/main/java/team/backend/curio/config/SecurityConfig.java
+++ b/src/main/java/team/backend/curio/config/SecurityConfig.java
@@ -23,7 +23,7 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/kakao/userinfo","/auth/google/userinfo","/articles/**").permitAll()  // 모든 경로 허용
+                        .requestMatchers("/auth/kakao/userinfo","/auth/google/userinfo","/articles/**","/search").permitAll()  // 모든 경로 허용
                         .anyRequest().authenticated()
                 )
 

--- a/src/main/java/team/backend/curio/controller/SearchController.java
+++ b/src/main/java/team/backend/curio/controller/SearchController.java
@@ -24,6 +24,7 @@ public class SearchController {
     public Page<SearchNewsResponseDto> search(
             @RequestParam String query,
             @RequestParam String type,
+            @RequestParam(defaultValue = "2") int summaryType,
             @Parameter(hidden = true) Pageable pageable
     ) {
         if (type.equalsIgnoreCase("news")) {

--- a/src/main/java/team/backend/curio/dto/NewsDTO/SearchNewsResponseDto.java
+++ b/src/main/java/team/backend/curio/dto/NewsDTO/SearchNewsResponseDto.java
@@ -1,13 +1,18 @@
 package team.backend.curio.dto.NewsDTO;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class SearchNewsResponseDto {
-    private Long id;
+    private Long newsId;
     private String title;
     private String content;
     private String imageUrl;
+
+    public SearchNewsResponseDto(Long newsId, String title, String content, String imageUrl) {
+        this.newsId = newsId;
+        this.title = title;
+        this.content = content;
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/team/backend/curio/repository/NewsSearchRepositoryImpl.java
+++ b/src/main/java/team/backend/curio/repository/NewsSearchRepositoryImpl.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import team.backend.curio.domain.QNews;
 import team.backend.curio.dto.NewsDTO.SearchNewsResponseDto;
+import com.querydsl.core.types.dsl.StringPath;
 
 import java.util.List;
 
@@ -27,7 +28,7 @@ public class NewsSearchRepositoryImpl implements NewsSearchRepository {
         for (String keyword : keywords) {
             condition.and(
                     news.title.containsIgnoreCase(keyword)
-                            .or(news.content.containsIgnoreCase(keyword))
+                            .or(news.content.like("%"+keyword+"%"))
             );
         }
 

--- a/src/main/java/team/backend/curio/security/JwtAuthenticationFilter.java
+++ b/src/main/java/team/backend/curio/security/JwtAuthenticationFilter.java
@@ -14,6 +14,7 @@ import team.backend.curio.domain.users;
 import team.backend.curio.repository.UserRepository;
 
 import java.io.IOException;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -22,11 +23,27 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
 
+    // 인증이 필요 없는 경로 리스트
+    private static final List<String> EXCLUDED_PATHS = List.of(
+            "/search",
+            "/articles",
+            "/auth/kakao/userinfo",
+            "/auth/google/userinfo"
+    );
+
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain)
             throws ServletException, IOException {
+
+        String uri = request.getRequestURI();
+
+        // 제외 경로는 인증 필터 건너뜀
+        if (EXCLUDED_PATHS.stream().anyMatch(uri::startsWith)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
 
         String token = jwtTokenProvider.resolveToken(request);
 


### PR DESCRIPTION
### 이슈 설명
검색정렬 api실행 시 로그인 없이 실행 될 수 있도록 코드 수정했습니다.

### api 테스트
<img width="1162" alt="검색정렬 api - 로그인없이 접근가능" src="https://github.com/user-attachments/assets/08ed11aa-003c-4e54-93f6-78fbd2926eda" />
